### PR TITLE
add random salvage generation across space ruins

### DIFF
--- a/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
+++ b/_maps/map_files/RandomRuins/SpaceRuins/abandoned_engi_sat.dmm
@@ -574,7 +574,6 @@
 "pX" = (
 /obj/structure/closet{
 	icon_state = "eng_secure";
-	opened = 1;
 	open_door_sprite = "eng_secure_door";
 	name = "engineer's locker"
 	},

--- a/code/controllers/subsystem/non_firing/SSmapping.dm
+++ b/code/controllers/subsystem/non_firing/SSmapping.dm
@@ -118,6 +118,65 @@ SUBSYSTEM_DEF(mapping)
 	else
 		world.name = station_name()
 
+/datum/controller/subsystem/mapping/proc/seed_space_salvage(space_z_levels)
+	log_startup_progress("Seeding space salvage...")
+	var/space_salvage_timer = start_watch()
+	var/seeded_salvage_surfaces = list()
+	var/seeded_salvage_closets = list()
+
+	var/list/small_salvage_items = list(
+		/obj/item/sellable/salvage/ruin/brick,
+		/obj/item/sellable/salvage/ruin/nanotrasen,
+		/obj/item/sellable/salvage/ruin/carp,
+		/obj/item/sellable/salvage/ruin/tablet
+	)
+
+	for(var/z_level in space_z_levels)
+		var/list/turf/z_level_turfs = block(locate(1, 1, z_level), locate(world.maxx, world.maxy, z_level))
+		for(var/z_level_turf in z_level_turfs)
+			var/turf/T = z_level_turf
+			var/area/A = get_area(T)
+			if(istype(A, /area/ruin/space))
+				for(var/obj/structure/closet/closet in T)
+					if(istype(closet, /obj/structure/closet/cardboard))
+						continue // otherwise deepstorage.dmm ends up hogging all the loot
+					if(istype(closet, /obj/structure/closet/fireaxecabinet))
+						continue
+					if(istype(closet, /obj/structure/closet/walllocker/emerglocker))
+						continue
+					if(istype(closet, /obj/structure/closet/crate/can))
+						continue // no valuable treasures in trash cans
+					if(istype(closet, /obj/structure/closet/body_bag))
+						continue
+					if(istype(closet, /obj/structure/closet/coffin))
+						continue
+
+					seeded_salvage_closets |= closet
+				for(var/obj/structure/table/table in T)
+					if(locate(/obj/machinery) in T)
+						continue // Machinery on tables tend to take up all the visible space
+					seeded_salvage_surfaces |= table
+
+	var/max_salvage_attempts = rand(10, 15)
+	while(max_salvage_attempts > 0 && length(seeded_salvage_closets) > 0)
+		var/obj/structure/closet/C = pick_n_take(seeded_salvage_closets)
+		var/salvage_item_type = pick(small_salvage_items)
+		var/obj/salvage_item = new salvage_item_type(C)
+		salvage_item.pixel_x = rand(-5, 5)
+		salvage_item.pixel_y = rand(-5, 5)
+		max_salvage_attempts -= 1
+
+	max_salvage_attempts = rand(10, 15)
+	while(max_salvage_attempts > 0 && length(seeded_salvage_surfaces) > 0)
+		var/obj/T = pick_n_take(seeded_salvage_surfaces)
+		var/salvage_item_type = pick(small_salvage_items)
+		var/obj/salvage_item = new salvage_item_type(T.loc)
+		salvage_item.pixel_x = rand(-5, 5)
+		salvage_item.pixel_y = rand(-5, 5)
+		max_salvage_attempts -= 1
+
+	log_startup_progress("Successfully seeded space salvage in [stop_watch(space_salvage_timer)]s.")
+
 // Do not confuse with seedRuins()
 /datum/controller/subsystem/mapping/proc/handleRuins()
 	// load in extra levels of space ruins
@@ -135,8 +194,10 @@ SUBSYSTEM_DEF(mapping)
 	// Note that this budget is not split evenly accross all zlevels
 	log_startup_progress("Seeding ruins...")
 	var/seed_ruins_timer = start_watch()
-	seedRuins(levels_by_trait(SPAWN_RUINS), rand(20, 30), /area/space, GLOB.space_ruins_templates)
+	var/space_z_levels = levels_by_trait(SPAWN_RUINS)
+	seedRuins(space_z_levels, rand(20, 30), /area/space, GLOB.space_ruins_templates)
 	log_startup_progress("Successfully seeded ruins in [stop_watch(seed_ruins_timer)]s.")
+	seed_space_salvage(space_z_levels)
 
 // Loads in the station
 /datum/controller/subsystem/mapping/proc/loadStation()


### PR DESCRIPTION
## What Does This PR Do

This PR adds dynamic salvage to space ruin generation.

This works by collecting a list of all tables and most closets generated in those z-levels, and then placing the smaller loot objects either on those tables or in the closets.

The following closet types are excluded from the list:

1. Cardboard boxes, because they bias placement in the survivalist bunker `deepstorage.dmm`.
2. Fireaxe cabinets, for obvious reasons.
3. Emergency lockers, because it's a little goofy.
4. Trash cans, because valuable loot probably wouldn't just be tossed in the trash.
5. Body bags, because it's a little goofy.
6. Coffins, because it's a little goofy.

They can spawn in abandoned crates, because that seems like a worthwhile reward for getting those open.

The number of loot placements is in the range of 20-30. If this is too much, I can reduce the amount.

Salvage seeding takes anywhere from 0.3-0.5s, which seems acceptable, but I don't know every performance trick so that might be able to be reduced.

This PR also closes the closets on the NT Abandoned Engineering Sat, so they can be used as spawn points without immediately showing the loot.

## Why It's Good For The Game

This implementation affords us two nice things:

1. Explorers will need to actually take the time to look through ruins more thoroughly if they want to find as much loot as possible.
2. This prevents mappers from having to place either static loot or static loot drops all over space ruins, which is tedious.

## Images of changes

Running an SDQL query for `/obj/item/sellable/salvage/ruin` returns the following:

![2024_03_08__11_13_47__](https://github.com/ItsMarmite/Paradise/assets/59303604/4e2a11b5-7619-45e7-8958-b095aa729b41)


You can see that a bunch of loot is in closets, and then a bunch more loot is placed all over (the pre-existing static loot placements are on top).

## Testing

Lots of spawning into ruins, checking contents, checking overall loot distribution.

## Changelog

:cl:
add: Salvage can be found in unexpected places! Be sure to check every ruin thoroughly, including the contents of lockers and other containers.
/:cl:
