### PR TITLE
add blackbox tracking for salvage sold

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -244,3 +244,6 @@
 			GLOB.station_money_database.credit_account(GLOB.station_money_database.get_account_by_department(DEPARTMENT_SCIENCE), research_credits, "Supply Shuttle Exports Payment", "Central Command Supply Master", supress_log = FALSE)
 		if(service_credits)
 			GLOB.station_money_database.credit_account(GLOB.station_money_database.get_account_by_department(DEPARTMENT_SERVICE), service_credits, "Supply Shuttle Exports Payment", "Central Command Supply Master", supress_log = FALSE)
+
+	// TODO: add stats for other stuff, find good representation for tech disks/levels because number of disks is meaningless
+	SSblackbox.record_feedback("tally", "cargo_exports", salvage_count, "salvage")


### PR DESCRIPTION
## What Does This PR Do
This PR adds blackbox tracking for number of salvage items sold to Centcomm.
## Why It's Good For The Game
Good to know how much a new mechanic is being used, and how it might affect balance based on the reward cost.
## Images of changes
![2024_03_08__12_13_27__Unnamed_paradise_gamedb_feedback_ - HeidiSQL 11 0 0 5919](https://github.com/ItsMarmite/Paradise/assets/59303604/b8981c6c-66bb-44d0-bcc6-717068818a39)
## Testing
Sold items to cargo, checked database after roundend.
## Changelog
NPFC
